### PR TITLE
Middleware Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 /routes/
 /app/
 /src/Controllers/
-/src/Middlewares/
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor/
 /public/
 /routes/
+/app/
 /src/Controllers/
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /routes/
 /app/
 /src/Controllers/
+/src/Middlewares/
 .idea

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     },
     "authors": [
         {
-            "name": "Rod1Andrade",
+            "name": "Rodrigo M.P Andrade",
             "email": "rodrigopires.profissional@gmail.com",
-            "role": "dev",
-            "homepage": "https://github.com/Rod1Andrade",
+            "role": "Developer",
+            "homepage": "https://github.com/Rod1Andrade"
         }
     ],
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     },
     "authors": [
         {
-            "name": "Rodrigo M.P Andrade",
+            "name": "Rod1Andrade",
             "email": "rodrigopires.profissional@gmail.com",
-            "role": "Developer",
+            "role": "dev",
             "homepage": "https://github.com/Rod1Andrade",
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,11 @@
 {
     "name": "rodri/simple-router",
     "description": "A simple router to API applications.",
+    "keywords": [
+        "routing",
+        "router",
+        "http"
+    ],
     "type": "library",
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     },
     "authors": [
         {
-            "name": "Rod1Andrade",
+            "name": "Rodrigo M.P Andrade",
             "email": "rodrigopires.profissional@gmail.com",
-            "role": "dev",
-            "homepage": "https://github.com/Rod1Andrade"
+            "role": "Developer",
+            "homepage": "https://github.com/Rod1Andrade",
         }
     ],
     "minimum-stability": "dev",

--- a/src/Handlers/HttpHandler.php
+++ b/src/Handlers/HttpHandler.php
@@ -5,6 +5,7 @@ namespace Rodri\SimpleRouter\Handlers;
 
 
 use Rodri\SimpleRouter\Helpers\ControllerMethod;
+use Rodri\SimpleRouter\Helpers\MiddlewareMethod;
 use Rodri\SimpleRouter\Helpers\StatusCode;
 use Rodri\SimpleRouter\Request;
 use Rodri\SimpleRouter\Response;
@@ -20,15 +21,33 @@ class HttpHandler extends RouterHandler
     public function __construct(
         private string $uri,
         private string $controller,
-        private string $method = 'GET'
+        private string $method = 'GET',
+        private array $middleware = [],
     )
     {
     }
 
     public function handle(Request $request): Response
     {
-        if ($this->validateRouter($request))
+        if ($this->validateRouter($request)) {
+
+            # Middleware in router Request handler
+            if(!empty($this->middleware)) {
+                foreach($this->middleware as $middleware) {
+                    # Instantiate a middleware
+                    $middlewareInstance = MiddlewareMethod::build($middleware);
+
+                    # Run in method
+                    $middlewareResponse = $middlewareInstance->call($request);
+
+                    if($middlewareResponse instanceof Response) {
+                        return $middlewareResponse;
+                    }
+                }
+            }
+
             return ControllerMethod::build($this->controller)->call($request);
+        }
 
         if ($this->getHandler())
             return $this->getHandler()->handle($request);

--- a/src/Handlers/HttpHandler.php
+++ b/src/Handlers/HttpHandler.php
@@ -4,11 +4,10 @@
 namespace Rodri\SimpleRouter\Handlers;
 
 
-use JetBrains\PhpStorm\Pure;
-use Rodri\SimpleRouter\Request;
-use Rodri\SimpleRouter\Response;
 use Rodri\SimpleRouter\Helpers\ControllerMethod;
 use Rodri\SimpleRouter\Helpers\StatusCode;
+use Rodri\SimpleRouter\Request;
+use Rodri\SimpleRouter\Response;
 
 /**
  * Class HttpHandler - Handler to HTTP REQUESTS
@@ -34,7 +33,7 @@ class HttpHandler extends RouterHandler
         if ($this->getHandler())
             return $this->getHandler()->handle($request);
 
-        return new Response(Response::NONE_VALUE, StatusCode::BAD_REQUEST);
+        return new Response(Response::INVALID_RESPONSE, StatusCode::BAD_REQUEST);
     }
 
     /**

--- a/src/Handlers/HttpHandler.php
+++ b/src/Handlers/HttpHandler.php
@@ -34,7 +34,7 @@ class HttpHandler extends RouterHandler
         if ($this->getHandler())
             return $this->getHandler()->handle($request);
 
-        return new Response(null, StatusCode::BAD_REQUEST);
+        return new Response(Response::NONE_VALUE, StatusCode::BAD_REQUEST);
     }
 
     /**

--- a/src/Handlers/RouterHandler.php
+++ b/src/Handlers/RouterHandler.php
@@ -6,8 +6,6 @@ namespace Rodri\SimpleRouter\Handlers;
 use ReflectionException;
 use Rodri\SimpleRouter\Request;
 use Rodri\SimpleRouter\Response;
-use Rodri\SimpleRouter\Helpers\ControllerMethod;
-use Rodri\SimpleRouter\Helpers\StatusCode;
 
 /**
  * Class RouterHandler

--- a/src/Helpers/ControllerMethod.php
+++ b/src/Helpers/ControllerMethod.php
@@ -31,8 +31,8 @@ class ControllerMethod
     {
         try {
             return $this->reflectionMethod->invoke(new $this->controller, $request);
-        } catch (ReflectionException $e) {
-            throw new ControllerMethodNotFoundException(Message::getError(Message::ERROR_CONTROLLER_NOT_FOUND));
+        } catch (ReflectionException) {
+            throw new ControllerMethodNotFoundException(Message::getError(Message::ERROR_CONTROLLER_METHOD_INVOCATION));
         }
     }
 
@@ -47,7 +47,7 @@ class ControllerMethod
 
         try {
             $controllerMethod->reflectionMethod = new ReflectionMethod($controller[0], $controller[1]);
-        } catch (ReflectionException $e) {
+        } catch (ReflectionException) {
             throw new ControllerMethodNotFoundException(Message::getError(Message::ERROR_CONTROLLER_NOT_FOUND));
         }
 

--- a/src/Helpers/ErrorHelper.php
+++ b/src/Helpers/ErrorHelper.php
@@ -30,6 +30,6 @@ class ErrorHelper
                 'trace' => $runtimeException->getTrace()
             ], StatusCode::INTERNAL_SERVER_ERROR);
 
-        return new Response(Response::NONE_VALUE, StatusCode::INTERNAL_SERVER_ERROR);
+        return new Response(Response::INVALID_RESPONSE, StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/Helpers/ErrorHelper.php
+++ b/src/Helpers/ErrorHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Rodri\SimpleRouter\Helpers;
+
+use Rodri\SimpleRouter\Response;
+use RuntimeException;
+
+/**
+ * Class ErrorHelper
+ * @package Rodri\SimpleRouter\Helpers
+ * @version 1.0.0
+ */
+class ErrorHelper
+{
+    /**
+     * @param RuntimeException $runtimeException
+     * @param bool $debugMode
+     * @return Response
+     */
+    public static function handle(RuntimeException $runtimeException, bool $debugMode = false): Response
+    {
+        if($debugMode)
+            return new Response([
+                'Mode' => 'Debug',
+                'error' => 'ControllerMethodNotFoundException',
+                'message' => $runtimeException->getMessage(),
+                'line' => $runtimeException->getLine(),
+                'file' => $runtimeException->getFile(),
+                'trace' => $runtimeException->getTrace()
+            ], StatusCode::INTERNAL_SERVER_ERROR);
+
+        return new Response(Response::NONE_VALUE, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/Helpers/Header.php
+++ b/src/Helpers/Header.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Rodri\SimpleRouter\Helpers;
+
+
+class Header
+{
+    public const APPLICATION_JSON = 'Content-type: application/json';
+    public const APPLICATION_JSON_UTF8 = 'Content-type: application/json;charset=utf-8';
+}

--- a/src/Helpers/MiddlewareMethod.php
+++ b/src/Helpers/MiddlewareMethod.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace Rodri\SimpleRouter\Helpers;
+
+
+use ReflectionException;
+use ReflectionMethod;
+use Rodri\SimpleRouter\Exceptions\ControllerMethodNotFoundException;
+use Rodri\SimpleRouter\Request;
+use Rodri\SimpleRouter\Response;
+use Rodri\SimpleRouter\utils\Message;
+
+/**
+ * Class MiddlewareMethod
+ * @package Rodri\SimpleRouter\utils
+ * @author Rodrigo Andrade
+ * @version 1.0.0
+ */
+class MiddlewareMethod
+{
+    private const METHOD_NAME = 'run';
+    private ReflectionMethod $reflectionMethod;
+    private string $middleware;
+
+    /**
+     * Instantiate a new Class of Controller execute appropriate method
+     * @param Request $request
+     * @return Response|bool|null
+     */
+    public function call(Request $request): Response|bool|null
+    {
+        try {
+            return $this->reflectionMethod->invoke(new $this->middleware, $request);
+        } catch (ReflectionException) {
+            throw new ControllerMethodNotFoundException(Message::getError(Message::ERROR_MIDDLEWARE_RUN_INVOCATION));
+        }
+    }
+
+    /**
+     * Build a new instance of ControllerMethod
+     */
+    public static function build(string $middleware): MiddlewareMethod
+    {
+        $middlewareMethod = new MiddlewareMethod();
+
+        try {
+            $middlewareMethod->reflectionMethod = new ReflectionMethod($middleware, MiddlewareMethod::METHOD_NAME);
+        } catch (ReflectionException) {
+            throw new ControllerMethodNotFoundException(Message::getError(Message::ERROR_MIDDLEWARE_NOT_FOUND));
+        }
+
+        $middlewareMethod->middleware = $middleware;
+
+        return $middlewareMethod;
+    }
+}

--- a/src/Middlewares/MiddlewareInterface.php
+++ b/src/Middlewares/MiddlewareInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Rodri\SimpleRouter\Middlewares;
+
+
+use Rodri\SimpleRouter\Request;
+use Rodri\SimpleRouter\Response;
+
+/**
+ * Interface Middleware
+ * @package Rodri\SimpleRouter\Middlewares
+ * @author Rodrigo Andrade
+ */
+interface MiddlewareInterface
+{
+    /**
+     * Operate in request and return True in success case.
+     * @param Request $request
+     * @return bool|Response TRUE in success case and Response otherwise.
+     */
+    public function run(Request $request): bool|Response;
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -14,6 +14,8 @@ use Rodri\SimpleRouter\Helpers\StatusCode;
  */
 class Response
 {
+    public const NONE_VALUE = 'NONE_VALUE_NULL';
+
     public function __construct(
         private mixed $response,
         String $statusCode = StatusCode::OK,
@@ -28,12 +30,12 @@ class Response
      */
     public function hasResponseValue(): bool
     {
-        return $this->response != null;
+        return $this->response !== Response::NONE_VALUE;
     }
 
     public function __toString(): string
     {
-        if($this->response != null)
+        if($this->hasResponseValue())
             return json_encode($this->response);
 
         return json_encode('');

--- a/src/Response.php
+++ b/src/Response.php
@@ -14,10 +14,11 @@ use Rodri\SimpleRouter\Helpers\StatusCode;
  */
 class Response
 {
-    public const NONE_VALUE = 'NONE_VALUE_NULL';
+    public const NONE_RESPONSE = '';
+    public const INVALID_RESPONSE = 'NONE_VALUE_NULL';
 
     public function __construct(
-        private mixed $response,
+        private mixed $response = Response::NONE_RESPONSE,
         String $statusCode = StatusCode::OK,
     )
     {
@@ -25,19 +26,24 @@ class Response
     }
 
     /**
-     * Check if has some response value.
+     * Check if has some response inavlid value.
      * @return bool
      */
-    public function hasResponseValue(): bool
+    public function hasInvalidResponse(): bool
     {
-        return $this->response !== Response::NONE_VALUE;
+        return $this->response !== Response::INVALID_RESPONSE;
     }
 
     public function __toString(): string
     {
-        if($this->hasResponseValue())
-            return json_encode($this->response);
+        if(empty($this->response)) {
+            return PHP_EOL;
+        }
 
-        return json_encode('');
+        if($this->hasInvalidResponse()) {
+            return json_encode($this->response);
+        }
+
+        return '';
     }
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -65,7 +65,6 @@ class Router
      */
     public function headerConfigs(array $configs)
     {
-        // TODO: Definir uma interface melhor para a definicao de headers.
         foreach ($configs as $config) {
             header($config);
         }
@@ -216,11 +215,11 @@ class Router
             if ($groupRouter instanceof Router) {
                 $response = $groupRouter->baseRouterHandler->handle(new Request());
 
-                if ($response->hasResponseValue())
+                if ($response->hasInvalidResponse())
                     return $response;
             }
         }
-        return new Response(Response::NONE_VALUE, StatusCode::BAD_REQUEST);
+        return new Response(Response::INVALID_RESPONSE, StatusCode::BAD_REQUEST);
     }
 
     /**
@@ -230,7 +229,7 @@ class Router
     {
         if ($this->baseRouterHandler)
             return $this->baseRouterHandler->handle(new Request());
-        return new Response(Response::NONE_VALUE, StatusCode::BAD_REQUEST);
+        return new Response(Response::INVALID_RESPONSE, StatusCode::BAD_REQUEST);
     }
 
     /**
@@ -242,7 +241,7 @@ class Router
     private function runHandles(): Response
     {
         $groupResponse = $this->dispatchGroupRoutes();
-        if ($groupResponse->hasResponseValue())
+        if ($groupResponse->hasInvalidResponse())
             return $groupResponse;
 
         return $this->dispatchBaseHandler();

--- a/src/Router.php
+++ b/src/Router.php
@@ -5,7 +5,6 @@ namespace Rodri\SimpleRouter;
 
 use Closure;
 use Exception;
-use PhpParser\Builder\Class_;
 use ReflectionException;
 use Rodri\SimpleRouter\Exceptions\ControllerMethodNotFoundException;
 use Rodri\SimpleRouter\Handlers\HttpHandler;
@@ -21,12 +20,12 @@ use Rodri\SimpleRouter\Helpers\StatusCode;
  */
 class Router
 {
-    # Attributes
     private ?RouterHandler $baseRouterHandler;
     private string $controllerNamespace;
     private bool $debugMode;
-    private ?string $baseUrl = null;
 
+    // TODO: Composer essa classe com uma classe GroupRouter com esses dois parametros abaixo
+    private ?string $baseUrl = null;
     private array $groupRouter;
 
     public function __construct()
@@ -66,6 +65,7 @@ class Router
      */
     public function headerConfigs(array $configs)
     {
+        // TODO: Definir uma interface melhor para a definicao de headers.
         foreach ($configs as $config) {
             header($config);
         }
@@ -212,10 +212,14 @@ class Router
      */
     public function dispatchGroupRoutes(): Response
     {
-        foreach ($this->groupRouter as $groupRouter)
-            if ($groupRouter instanceof Router)
-                return $groupRouter->baseRouterHandler->handle(new Request());
+        foreach ($this->groupRouter as $groupRouter) {
+            if ($groupRouter instanceof Router) {
+                $response = $groupRouter->baseRouterHandler->handle(new Request());
 
+                if ($response->hasResponseValue())
+                    return $response;
+            }
+        }
         return new Response(Response::NONE_VALUE, StatusCode::BAD_REQUEST);
     }
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -5,6 +5,7 @@ namespace Rodri\SimpleRouter;
 
 use Closure;
 use Exception;
+use JetBrains\PhpStorm\Pure;
 use ReflectionException;
 use Rodri\SimpleRouter\Exceptions\ControllerMethodNotFoundException;
 use Rodri\SimpleRouter\Handlers\HttpHandler;
@@ -16,23 +17,29 @@ use Rodri\SimpleRouter\Helpers\StatusCode;
  * Class Router
  * @package Rodri\SimpleRouter
  * @author Rodrigo Andrade
- * @version 1.0.0
+ * @version 1.1.1
  */
 class Router
 {
+    private const INDEX_ROUTER_MIDDLEWARE = 'middleware';
+
     private ?RouterHandler $baseRouterHandler;
+
     private string $controllerNamespace;
+    private string $middlewareNamespace;
+
     private bool $debugMode;
 
-    // TODO: Composer essa classe com uma classe GroupRouter com esses dois parametros abaixo
-    private ?string $baseUrl = null;
-    private array $groupRouter;
+    private ?string $groupBaseUrl = null;
+    private array|string $groupBaseMiddleware = [];
+
+    private array $groupRouters;
 
     public function __construct()
     {
         $this->baseRouterHandler = null;
         $this->debugMode = false;
-        $this->groupRouter = array();
+        $this->groupRouters = array();
     }
 
     /**
@@ -44,10 +51,11 @@ class Router
     }
 
     /**
-     * @param string $string
+     * @param string $namespace
      */
-    public function setMiddlewareNamespace(string $string): void
+    public function setMiddlewareNamespace(string $namespace): void
     {
+        $this->middlewareNamespace = $namespace;
     }
 
     /**
@@ -91,7 +99,7 @@ class Router
      */
     public function addRouterGroup(Router $router): void
     {
-        $this->groupRouter[] = $router;
+        $this->groupRouters[] = $router;
     }
 
     /**
@@ -103,8 +111,8 @@ class Router
     public function group(array $routerOptions, Closure $closure): void
     {
         $router = clone $this;
-        $router->baseUrl = $routerOptions[0];
-
+        $router->groupBaseUrl = $routerOptions[0];
+        $router->groupBaseMiddleware = $routerOptions[self::INDEX_ROUTER_MIDDLEWARE];
         # Pass to closure function a instate of route
         $closure($router);
 
@@ -122,14 +130,15 @@ class Router
             new HttpHandler(
                 $this->buildURI($routerOptions[0]),
                 $this->concatControllerAndNamespace($controller),
-                'GET'
+                'GET',
+                $this->getMiddlewares($routerOptions)
             )
         );
     }
 
     /**
      * POST
-     * @param array $routerOptions Router options [0] => '/router' ['middleware' => Middleware
+     * @param array $routerOptions Router options [0] => '/router' ['middleware' => Middleware]
      * @param String $controller Controller by pattern Controller#method
      */
     public function post(array $routerOptions, string $controller): void
@@ -138,7 +147,8 @@ class Router
             new HttpHandler(
                 $this->buildURI($routerOptions[0]),
                 $this->concatControllerAndNamespace($controller),
-                'POST'
+                'POST',
+                $this->getMiddlewares($routerOptions)
             )
         );
     }
@@ -154,7 +164,8 @@ class Router
             new HttpHandler(
                 $this->buildURI($routerOptions[0]),
                 $this->concatControllerAndNamespace($controller),
-                'PUT'
+                'PUT',
+                $this->getMiddlewares($routerOptions)
             )
         );
     }
@@ -170,7 +181,8 @@ class Router
             new HttpHandler(
                 $this->buildURI($routerOptions[0]),
                 $this->concatControllerAndNamespace($controller),
-                'PATCH'
+                'PATCH',
+                $this->getMiddlewares($routerOptions)
             )
         );
     }
@@ -186,7 +198,8 @@ class Router
             new HttpHandler(
                 $this->buildURI($routerOptions[0]),
                 $this->concatControllerAndNamespace($controller),
-                'DELETE'
+                'DELETE',
+                $this->getMiddlewares($routerOptions)
             )
         );
     }
@@ -211,7 +224,7 @@ class Router
      */
     public function dispatchGroupRoutes(): Response
     {
-        foreach ($this->groupRouter as $groupRouter) {
+        foreach ($this->groupRouters as $groupRouter) {
             if ($groupRouter instanceof Router) {
                 $response = $groupRouter->baseRouterHandler->handle(new Request());
 
@@ -257,14 +270,64 @@ class Router
     }
 
     /**
+     * @param string $middleware
+     * @return string
+     */
+    private function concatMiddlewareAndNamespace(string $middleware): string
+    {
+        return $this->middlewareNamespace . '\\' . $middleware;
+    }
+
+    /**
+     * @param array $routerOptions
+     * @return array
+     */
+    #[Pure] private function getMiddlewares(array $routerOptions): array
+    {
+        # Middlewares of group
+        $groupMiddlewares = [];
+        if (!empty($this->groupBaseMiddleware) && is_string($this->groupBaseMiddleware)) {
+            $groupMiddlewares[] = $this->concatMiddlewareAndNamespace($this->groupBaseMiddleware);
+        }
+
+        if (!empty($this->groupBaseMiddleware) && is_array($this->groupBaseMiddleware)) {
+            foreach ($this->groupBaseMiddleware as $middlewareItem) {
+                $groupMiddlewares[] = $this->concatMiddlewareAndNamespace($middlewareItem);
+            }
+        }
+
+        # If just exist the middleware of group return it.
+        if (!isset($routerOptions[Router::INDEX_ROUTER_MIDDLEWARE])) {
+            return $groupMiddlewares;
+        }
+
+        # If not, merge them
+        if (is_string($routerOptions[Router::INDEX_ROUTER_MIDDLEWARE])) {
+            $middleware = empty($routerOptions[Router::INDEX_ROUTER_MIDDLEWARE]) ? [] : [$this->concatMiddlewareAndNamespace($routerOptions[Router::INDEX_ROUTER_MIDDLEWARE])];
+            return array_merge($groupMiddlewares, $middleware);
+        }
+
+        if (is_array($routerOptions[Router::INDEX_ROUTER_MIDDLEWARE])) {
+            $middlewares = [];
+            foreach ($routerOptions[Router::INDEX_ROUTER_MIDDLEWARE] as $middlewareItem) {
+                $middlewares[] = $this->concatMiddlewareAndNamespace($middlewareItem);
+            }
+
+            return array_merge($groupMiddlewares, $middlewares);
+        }
+
+        return [];
+    }
+
+    /**
      * Build a URI with a base URL if exist
      * @param String $route
      * @return String
      */
     private function buildURI(string $route): string
     {
-        if (isset($this->baseUrl)) {
-            $route = $this->baseUrl . $route;
+        if (isset($this->groupBaseUrl)) {
+            $route = $this->groupBaseUrl . $route;
         }
 
         return $route;

--- a/src/Router.php
+++ b/src/Router.php
@@ -205,31 +205,12 @@ class Router
     }
 
     /**
-     * Run the appropriate handle or Group or Normal.
-     *
-     * @return Response
-     * @throws ReflectionException
-     */
-    private function runHandles(): Response
-    {
-        $groupResponse = $this->dispatchGroupRoutes();
-
-        if($groupResponse->hasResponseValue()) {
-            return $groupResponse;
-        } else if($this->baseRouterHandler) {
-            return $this->dispatchBaseHandler();
-        }
-
-        return new Response(Response::NONE_VALUE, StatusCode::BAD_REQUEST);
-    }
-
-    /**
      * Dispatch all grouped routes.
      *
      * @return Response
      * @throws ReflectionException
      */
-    private function dispatchGroupRoutes(): Response
+    public function dispatchGroupRoutes(): Response
     {
         foreach ($this->groupRouter as $groupRouter)
             if ($groupRouter instanceof Router)
@@ -241,9 +222,26 @@ class Router
     /**
      * @throws ReflectionException
      */
-    private function dispatchBaseHandler(): Response
+    public function dispatchBaseHandler(): Response
     {
-        return $this->baseRouterHandler->handle(new Request());
+        if ($this->baseRouterHandler)
+            return $this->baseRouterHandler->handle(new Request());
+        return new Response(Response::NONE_VALUE, StatusCode::BAD_REQUEST);
+    }
+
+    /**
+     * Run the appropriate handle or Group or Normal.
+     *
+     * @return Response
+     * @throws ReflectionException
+     */
+    private function runHandles(): Response
+    {
+        $groupResponse = $this->dispatchGroupRoutes();
+        if ($groupResponse->hasResponseValue())
+            return $groupResponse;
+
+        return $this->dispatchBaseHandler();
     }
 
     /**

--- a/src/Router.php
+++ b/src/Router.php
@@ -200,7 +200,6 @@ class Router
     {
         try {
             echo $this->runHandles($this->dispatchGroupRoutes(), $this->baseRouterHandler);
-            flush();
         } catch (ControllerMethodNotFoundException | ReflectionException $e) {
             echo ErrorHelper::handle($e, $this->debugMode);
         }
@@ -210,6 +209,7 @@ class Router
      * Run the appropriate handle or Group or Normal.
      *
      * @param Response $response
+     * @param RouterHandler $baseHandler
      * @return Response
      * @throws ReflectionException
      */

--- a/src/utils/Message.php
+++ b/src/utils/Message.php
@@ -4,8 +4,6 @@
 namespace Rodri\SimpleRouter\utils;
 
 
-use PhpParser\Node\Scalar\String_;
-
 class Message
 {
 
@@ -13,8 +11,12 @@ class Message
 
     # Attributes
     private array $errorMessages;
+
     public const ERROR_CONTROLLER_NOT_FOUND = 0;
     public const ERROR_CONTROLLER_METHOD_INVOCATION = 1;
+
+    public const ERROR_MIDDLEWARE_NOT_FOUND = 3;
+    public const ERROR_MIDDLEWARE_RUN_INVOCATION = 4;
 
     private function __construct()
     {
@@ -40,7 +42,8 @@ class Message
     {
         $this->errorMessages = [
             Message::ERROR_CONTROLLER_NOT_FOUND => 'Check if the controller namespace is defined and if has a correspond method.',
-            Message::ERROR_CONTROLLER_METHOD_INVOCATION => 'Is not possible invoke the controller method, maybe some param is expected.'
+            Message::ERROR_CONTROLLER_METHOD_INVOCATION => 'Is not possible invoke the controller method, maybe some param is expected.',
+            Message::ERROR_MIDDLEWARE_RUN_INVOCATION => 'Is not possible invoke the Middleware run method, maybe some param is expected.. or you not implements the Middleware Interface.'
         ];
     }
 


### PR DESCRIPTION
# Goal

Possibility to implement a middleware for each router and group router.

```php
use Rodri\SimpleRouter\Helpers\Header;
use Rodri\SimpleRouter\Router;

# Application Routers
$router = new Router();

$router->headerConfigs([
    Header::APPLICATION_JSON_UTF8,
]);

$router->setControllerNamespace('Rodri\SimpleRouter\Controllers');
$router->setMiddlewareNamespace('Rodri\SimpleRouter\Middlewares');

$router->debug(true);

$router->get(['/aloneGet', 'middleware' => ['GetMiddleware', 'OtherMiddleware', 'FailedMiddleware']], 'RequestController#get');

$router->group(['/request', 'middleware' => 'OtherMiddleware'], function (Router $router) {
    $router->get(['/get', 'middleware' => 'FailedMiddleware'], 'RequestController#get');
    $router->post(['/post'], 'RequestController#post');
});

# Dispatch router
$router->dispatch();

```

## How it works

- Nothing has been changed to use a normal route, just if you need to have a middleware, its necessary create a class wich implements MiddlewareInterface and return true for a expected result to the middleware and return Response object with has some kind of error.
- Is totally possible create a middleware to a alone router and a middleware to a group router and a unique method of router can have a different middleware if you want.